### PR TITLE
Bad mint panic (Websoft #3)

### DIFF
--- a/cmd/kiichaind/cmd/blocktest.go
+++ b/cmd/kiichaind/cmd/blocktest.go
@@ -21,7 +21,7 @@ import (
 	evmtypes "github.com/kiichain/kiichain3/x/evm/types"
 	"github.com/tendermint/tendermint/libs/log"
 
-	//nolint:gosec,G108
+	//nolint:gosec
 	_ "net/http/pprof"
 )
 

--- a/cmd/kiichaind/cmd/ethreplay.go
+++ b/cmd/kiichaind/cmd/ethreplay.go
@@ -21,7 +21,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"net/http"
-	//nolint:gosec,G108
+	//nolint:gosec
 	_ "net/http/pprof"
 )
 

--- a/x/mint/keeper/hooks.go
+++ b/x/mint/keeper/hooks.go
@@ -5,37 +5,56 @@ import (
 	epochTypes "github.com/kiichain/kiichain3/x/epoch/types"
 )
 
+// BeforeEpochStart is a hook that's ran after an epoch starts
 func (k Keeper) BeforeEpochStart(_ sdk.Context, _ epochTypes.Epoch) {}
 
+// AfterEpochEnd is a hook that's ran after an epoch ends
 func (k Keeper) AfterEpochEnd(ctx sdk.Context, epoch epochTypes.Epoch) {
-	latestMinter := k.GetOrUpdateLatestMinter(ctx, epoch)
-	coinsToMint := latestMinter.GetReleaseAmountToday(epoch.CurrentEpochStartTime.UTC())
+	// Get the latest minter
+	latestMinter, err := k.GetOrUpdateLatestMinter(ctx, epoch)
+	if err != nil {
+		// We can panic, it's common for hooks to panic
+		// The panic is captured on epoch hooks
+		panic(err)
+	}
 
+	// Get the coinsToMint
+	coinsToMint, err := latestMinter.GetReleaseAmountToday(epoch.CurrentEpochStartTime.UTC())
+	if err != nil {
+		panic(err)
+	}
+
+	// Get the remaining mint amount
 	if coinsToMint.IsZero() || latestMinter.GetRemainingMintAmount() == 0 {
 		k.Logger(ctx).Debug("No coins to mint", "minter", latestMinter)
-		return
 	}
 
 	// mint coins, update supply
 	if err := k.MintCoins(ctx, coinsToMint); err != nil {
+		// We can panic, it's common for hooks to panic
+		// The panic is captured, logged and handled on epoch hooks
 		panic(err)
 	}
 	// send the minted coins to the fee collector account
 	if err := k.AddCollectedFees(ctx, coinsToMint); err != nil {
+		// We can panic, it's common for hooks to panic
+		// The panic is captured, logged and handled on epoch hooks
 		panic(err)
 	}
 
-	// Released Succssfully, decrement the remaining amount by the daily release amount and update minter
+	// Released successfully, decrement the remaining amount by the daily release amount and update minter
 	amountMinted := coinsToMint.AmountOf(latestMinter.GetDenom())
 	latestMinter.RecordSuccessfulMint(ctx, epoch, amountMinted.Uint64())
 	k.Logger(ctx).Info("Minted coins", "minter", latestMinter, "amount", coinsToMint.String())
 	k.SetMinter(ctx, latestMinter)
 }
 
+// Hooks is the hook struct for the mint module
 type Hooks struct {
 	k Keeper
 }
 
+// Assert the interface
 var _ epochTypes.EpochHooks = Hooks{}
 
 // Return the wrapper struct.
@@ -43,11 +62,12 @@ func (k Keeper) Hooks() Hooks {
 	return Hooks{k}
 }
 
-// epochs hooks.
+// Epoch hook for before epoch start
 func (h Hooks) BeforeEpochStart(ctx sdk.Context, epoch epochTypes.Epoch) {
 	h.k.BeforeEpochStart(ctx, epoch)
 }
 
+// Epoch hook for before after start
 func (h Hooks) AfterEpochEnd(ctx sdk.Context, epoch epochTypes.Epoch) {
 	h.k.AfterEpochEnd(ctx, epoch)
 }

--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -50,49 +50,76 @@ func ValidateMinter(minter Minter) error {
 	if minter.GetTotalMintAmount() < minter.GetRemainingMintAmount() {
 		return fmt.Errorf("total mint amount cannot be less than remaining mint amount")
 	}
-	endDate := minter.GetEndDateTime()
-	startDate := minter.GetStartDateTime()
+
+	// Get the end date
+	endDate, err := minter.GetEndDateTime()
+	if err != nil {
+		return err
+	}
+
+	// Get the start date
+	startDate, err := minter.GetStartDateTime()
+	if err != nil {
+		return err
+	}
+
+	// Compare the end and start date
+	// End must be after start
 	if endDate.Before(startDate) {
 		return fmt.Errorf("end date must be after start date %s < %s", endDate, startDate)
 	}
 	return validateMintDenom(minter.Denom)
 }
 
-func (m *Minter) GetLastMintDateTime() time.Time {
-	lastMinteDateTime, err := time.Parse(TokenReleaseDateFormat, m.GetLastMintDate())
+// GetLastMintDateTime returns the last time tokens were minted
+func (m *Minter) GetLastMintDateTime() (time.Time, error) {
+	lastMintedDateTime, err := time.Parse(TokenReleaseDateFormat, m.GetLastMintDate())
 	if err != nil {
 		// This should not happen as the date is validated when the minter is created
-		panic(fmt.Errorf("invalid end date for current minter: %s, minter=%s", err, m.String()))
+		return time.Time{}, fmt.Errorf("invalid end date for current minter: %s, minter=%s", err, m.String())
 	}
-	return lastMinteDateTime.UTC()
+	return lastMintedDateTime.UTC(), nil
 }
 
-func (m *Minter) GetStartDateTime() time.Time {
+// GetStartDateTime returns the minter last start date
+func (m *Minter) GetStartDateTime() (time.Time, error) {
 	startDateTime, err := time.Parse(TokenReleaseDateFormat, m.GetStartDate())
 	if err != nil {
 		// This should not happen as the date is validated when the minter is created
-		panic(fmt.Errorf("invalid end date for current minter: %s, minter=%s", err, m.String()))
+		return time.Time{}, fmt.Errorf("invalid start date for current minter: %s, minter=%s", err, m.String())
 	}
-	return startDateTime.UTC()
+	return startDateTime.UTC(), nil
 }
 
-func (m *Minter) GetEndDateTime() time.Time {
+// GetEndDateTime returns the minter last end date
+func (m *Minter) GetEndDateTime() (time.Time, error) {
 	endDateTime, err := time.Parse(TokenReleaseDateFormat, m.GetEndDate())
 	if err != nil {
 		// This should not happen as the date is validated when the minter is created
-		panic(fmt.Errorf("invalid end date for current minter: %s, minter=%s", err, m.String()))
+		return time.Time{}, fmt.Errorf("invalid end date for current minter: %s, minter=%s", err, m.String())
 	}
-	return endDateTime.UTC()
+	return endDateTime.UTC(), nil
 }
 
+// GetLastMintAmountCoin returns the minter last mint amount
 func (m Minter) GetLastMintAmountCoin() sdk.Coin {
 	return sdk.NewCoin(m.GetDenom(), sdk.NewInt(int64(m.GetLastMintAmount())))
 }
 
-func (m *Minter) GetReleaseAmountToday(currentTime time.Time) sdk.Coins {
-	return sdk.NewCoins(sdk.NewCoin(m.GetDenom(), sdk.NewInt(int64(m.getReleaseAmountToday(currentTime.UTC())))))
+// GetReleaseAmountToday takes the current time and returns the amount to be release as mint in coins
+func (m *Minter) GetReleaseAmountToday(currentTime time.Time) (sdk.Coins, error) {
+	// Get the amount to release today
+	amountToRelease, err := m.getReleaseAmountToday(currentTime.UTC())
+	if err != nil {
+		return nil, err
+	}
+
+	// Transform into a coin and return
+	amountToReleaseCoin := sdk.NewCoins(sdk.NewCoin(m.GetDenom(), sdk.NewInt(int64(amountToRelease))))
+	return amountToReleaseCoin, nil
 }
 
+// RecordSuccessfulMint records a successful mint process
 func (m *Minter) RecordSuccessfulMint(ctx sdk.Context, epoch epochTypes.Epoch, mintedAmount uint64) {
 	m.RemainingMintAmount -= mintedAmount
 	m.LastMintDate = epoch.CurrentEpochStartTime.Format(TokenReleaseDateFormat)
@@ -109,31 +136,58 @@ func (m *Minter) RecordSuccessfulMint(ctx sdk.Context, epoch epochTypes.Epoch, m
 	)
 }
 
-func (m *Minter) getReleaseAmountToday(currentTime time.Time) uint64 {
+// getReleaseAmountToday returns the amount to the released as mint value on the day
+func (m *Minter) getReleaseAmountToday(currentTime time.Time) (uint64, error) {
+	// Get the start date
+	startDate, err := m.GetStartDateTime()
+	if err != nil {
+		return 0, err
+	}
+
 	// Not yet started or already minted today
-	if currentTime.Before(m.GetStartDateTime()) || currentTime.Format(TokenReleaseDateFormat) == m.GetLastMintDate() {
-		return 0
+	if currentTime.Before(startDate) || currentTime.Format(TokenReleaseDateFormat) == m.GetLastMintDate() {
+		return 0, nil
 	}
 
-	// if it's already past the end date then release the remaining amount likely caused by outage
-	numberOfDaysLeft := m.GetNumberOfDaysLeft(currentTime)
-	if currentTime.After(m.GetEndDateTime()) || numberOfDaysLeft == 0 {
-		return m.GetRemainingMintAmount()
+	// Get the end date
+	endDate, err := m.GetEndDateTime()
+	if err != nil {
+		return 0, err
 	}
 
-	return m.GetRemainingMintAmount() / numberOfDaysLeft
+	// Get the number of days left
+	numberOfDaysLeft, err := m.GetNumberOfDaysLeft(currentTime)
+	if err != nil {
+		return 0, err
+	}
+
+	// If it's already past the end date then release the remaining amount likely caused by outage
+	if currentTime.After(endDate) || numberOfDaysLeft == 0 {
+		return m.GetRemainingMintAmount(), nil
+	}
+
+	return m.GetRemainingMintAmount() / numberOfDaysLeft, nil
 }
 
-func (m *Minter) GetNumberOfDaysLeft(currentTime time.Time) uint64 {
+// GetNumberOfDaysLeft returns the number of days left before next mint
+func (m *Minter) GetNumberOfDaysLeft(currentTime time.Time) (uint64, error) {
+	// Get the end date
+	endDate, err := m.GetEndDateTime()
+	if err != nil {
+		return 0, err
+	}
+
 	// If the last mint date is after the start date then use the last mint date as there's an ongoing release
-	daysBetween := DaysBetween(currentTime, m.GetEndDateTime())
-	return daysBetween
+	daysBetween := DaysBetween(currentTime, endDate)
+	return daysBetween, nil
 }
 
+// OngoingRelease returns if there's a ongoing mint release
 func (m *Minter) OngoingRelease() bool {
 	return m.GetRemainingMintAmount() != 0
 }
 
+// DaysBetween returns days in between two dates
 func DaysBetween(a, b time.Time) uint64 {
 	// Convert both times to UTC before comparing
 	aYear, aMonth, aDay := a.UTC().Date()


### PR DESCRIPTION
# Description

This solves Websoft issue #3:
```text
Description:
Direct panic calls in time parsing in minter.go functions(GetStartDateTime/GetEndDateTime) could halt chain operation if date format corruption occurs.

Recommendation:
Implement error handling instead of panic, with state recovery mechanisms
```

This changes the error handling on the mint app.
- This PR is not consensus breaking

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

New unit and integration tests added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works