### PR TITLE
Fix EVM codecs (Websoft #10)

### DIFF
--- a/x/evm/types/message_evm_transaction_test.go
+++ b/x/evm/types/message_evm_transaction_test.go
@@ -26,10 +26,10 @@ func TestIsAssociate(t *testing.T) {
 }
 
 func TestIsNotAssociate(t *testing.T) {
-	tx, err := types.NewMsgEVMTransaction(nil)
+	_, err := types.NewMsgEVMTransaction(nil)
 	require.Error(t, err)
 
-	tx, err = types.NewMsgEVMTransaction(&ethtx.AccessTuple{})
+	tx, err := types.NewMsgEVMTransaction(&ethtx.AccessTuple{})
 	require.Nil(t, err)
 	require.False(t, tx.IsAssociateTx())
 }
@@ -57,7 +57,9 @@ func TestAsTransaction(t *testing.T) {
 
 	signer := ethtypes.MakeSigner(ethCfg, blockNum, uint64(ctx.BlockTime().Unix()))
 	tx, err := ethtypes.SignTx(ethtypes.NewTx(&txData), signer, key)
+	require.NoError(t, err)
 	typedTx, err := ethtx.NewDynamicFeeTx(tx)
+	require.NoError(t, err)
 	msg, err := types.NewMsgEVMTransaction(typedTx)
 	require.Nil(t, err)
 	ethTx, ethTxData := msg.AsTransaction()


### PR DESCRIPTION
# Description

This solves Websoft issue #10:
```
Description:
MsgAssociate, MsgInternalEVMCall and MsgInternalEVMDelegateCall are not registered in RegisterInterfaces in x/evm/types/codec.go. Hence the module will not route the messages to an appropriate server.

Recommendation:
Register the interface accordingly.
```

This register the interfaces for:
- `MsgAssociate`
- `MsgInternalEVMCall`
- `MsgInternalEVMDelegateCall`

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

No new tests needed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works