### PR TITLE
Fix unchecked fee (Websoft #9)

### DIFF
--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -539,6 +539,17 @@ func (k *Keeper) getReplayBlockCtx(ctx sdk.Context) (*vm.BlockContext, error) {
 	}, nil
 }
 
+// ClearCachedFeeCollectorAddress clear the fee collector address from memory
+// This is used in tests
+func (k *Keeper) ClearCachedFeeCollectorAddress() {
+	// Lock the mutex
+	k.cachedFeeCollectorAddressMtx.Lock()
+	// Clear it out (nil)
+	k.cachedFeeCollectorAddress = nil
+	// Unlock the mutex
+	k.cachedFeeCollectorAddressMtx.Unlock()
+}
+
 func uint64Cmp(a, b uint64) int {
 	if a < b {
 		return -1

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -16,6 +16,21 @@ import (
 	"github.com/kiichain/kiichain3/x/evm/types"
 )
 
+// TestStateDBBadInitialization test the NewDBImpl with a bad EVM module address association
+// This test must go first to avoid initialization from other tests
+func TestStateDBBadInitialization(t *testing.T) {
+	// Get the keeper from the EVM test app
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	// Start a new empty context, this clear out the EVM module address association
+	ctx := testkeeper.EVMTestApp.NewContext(true, tmproto.Header{Height: testkeeper.EVMTestApp.LastBlockHeight()})
+
+	// Run the NewDBImpl, it should panic
+	require.Panics(t, func() {
+		// Run the function, the result is not important
+		_ = state.NewDBImpl(ctx, k, false)
+	}, "Expected NewDBImpl to panic")
+}
+
 func TestState(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
 	ctx := testkeeper.EVMTestApp.GetContextForDeliverTx([]byte{}).WithBlockTime(time.Now())
@@ -176,19 +191,4 @@ func TestSnapshot(t *testing.T) {
 	require.Equal(t, common.Hash{}, newStateDB.GetTransientState(evmAddr, tkey))
 	require.Equal(t, val, newStateDB.GetState(evmAddr, key))
 	require.Equal(t, eventCount+1, len(ctx.EventManager().Events()))
-}
-
-// TestStateDBBadInitialization test the NewDBImpl with a bad EVM module address association
-func TestStateDBBadInitialization(t *testing.T) {
-	// Get the keeper from the EVM test app
-	k := &testkeeper.EVMTestApp.EvmKeeper
-	// Start a new empty context, this clear out the EVM module address association
-	ctx := testkeeper.EVMTestApp.NewContext(true, tmproto.Header{Height: testkeeper.EVMTestApp.LastBlockHeight()})
-
-	// Run the NewDBImpl, it should panic
-
-	require.Panics(t, func() {
-		// Run the function, the result is not important
-		_ = state.NewDBImpl(ctx, k, false)
-	}, "Expected NewDBImpl to panic")
 }

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -16,20 +16,11 @@ import (
 	"github.com/kiichain/kiichain3/x/evm/types"
 )
 
-// TestStateDBBadInitialization test the NewDBImpl with a bad EVM module address association
-// This test must go first to avoid initialization from other tests
-func TestStateDBBadInitialization(t *testing.T) {
-	// Get the keeper from the EVM test app
-	k := &testkeeper.EVMTestApp.EvmKeeper
-	// Start a new empty context, this clear out the EVM module address association
-	ctx := testkeeper.EVMTestApp.NewContext(true, tmproto.Header{Height: testkeeper.EVMTestApp.LastBlockHeight()})
-
-	// Run the NewDBImpl, it should panic
-	require.Panics(t, func() {
-		// Run the function, the result is not important
-		_ = state.NewDBImpl(ctx, k, false)
-	}, "Expected NewDBImpl to panic")
-}
+var (
+	// This empty context is used specifically on the TestStateDBBadInitialization
+	// Don't reuse it in other tests
+	emptyContext = testkeeper.EVMTestApp.NewContext(true, tmproto.Header{Height: testkeeper.EVMTestApp.LastBlockHeight()})
+)
 
 func TestState(t *testing.T) {
 	k := &testkeeper.EVMTestApp.EvmKeeper
@@ -191,4 +182,17 @@ func TestSnapshot(t *testing.T) {
 	require.Equal(t, common.Hash{}, newStateDB.GetTransientState(evmAddr, tkey))
 	require.Equal(t, val, newStateDB.GetState(evmAddr, key))
 	require.Equal(t, eventCount+1, len(ctx.EventManager().Events()))
+}
+
+// TestStateDBBadInitialization test the NewDBImpl with a bad EVM module address association
+// This test must go first to avoid initialization from other tests
+func TestStateDBBadInitialization(t *testing.T) {
+	// Get the keeper from the EVM test app
+	k := &testkeeper.EVMTestApp.EvmKeeper
+
+	// Run the NewDBImpl, it should panic
+	require.Panics(t, func() {
+		// Run the function, the result is not important
+		_ = state.NewDBImpl(emptyContext, k, false)
+	}, "Expected NewDBImpl to panic")
 }

--- a/x/evm/state/state_test.go
+++ b/x/evm/state/state_test.go
@@ -8,10 +8,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
 	testkeeper "github.com/kiichain/kiichain3/testutil/keeper"
 	"github.com/kiichain/kiichain3/x/evm/state"
 	"github.com/kiichain/kiichain3/x/evm/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestState(t *testing.T) {
@@ -174,4 +176,19 @@ func TestSnapshot(t *testing.T) {
 	require.Equal(t, common.Hash{}, newStateDB.GetTransientState(evmAddr, tkey))
 	require.Equal(t, val, newStateDB.GetState(evmAddr, key))
 	require.Equal(t, eventCount+1, len(ctx.EventManager().Events()))
+}
+
+// TestStateDBBadInitialization test the NewDBImpl with a bad EVM module address association
+func TestStateDBBadInitialization(t *testing.T) {
+	// Get the keeper from the EVM test app
+	k := &testkeeper.EVMTestApp.EvmKeeper
+	// Start a new empty context, this clear out the EVM module address association
+	ctx := testkeeper.EVMTestApp.NewContext(true, tmproto.Header{Height: testkeeper.EVMTestApp.LastBlockHeight()})
+
+	// Run the NewDBImpl, it should panic
+
+	require.Panics(t, func() {
+		// Run the function, the result is not important
+		_ = state.NewDBImpl(ctx, k, false)
+	}, "Expected NewDBImpl to panic")
 }

--- a/x/evm/state/statedb.go
+++ b/x/evm/state/statedb.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -39,7 +41,12 @@ type DBImpl struct {
 }
 
 func NewDBImpl(ctx sdk.Context, k EVMKeeper, simulation bool) *DBImpl {
-	feeCollector, _ := k.GetFeeCollectorAddress(ctx)
+	feeCollector, err := k.GetFeeCollectorAddress(ctx)
+	if err != nil {
+		// If no fee collection address has been found,
+		// we can panic at the database initialization
+		panic(fmt.Errorf("failed to get fee collection address for the EVM module with err: %s", err))
+	}
 	s := &DBImpl{
 		ctx:                ctx,
 		k:                  k,


### PR DESCRIPTION
# Description

This solves Websoft issue #9:
```
Description:
GetFeeCollectorAddress ignores the error which could lead to lost fees

Recommendation:
Handle the error and panic or return error if fee collector is invalid
```

This forces the NewDBImpl to panic if EVM FeeCollector is not set.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

New test added to check the bad path

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works