### PR TITLE
Improve account creation restriction (Websoft #8)

### DIFF
--- a/app/ante_test.go
+++ b/app/ante_test.go
@@ -187,7 +187,7 @@ func (suite *AnteTestSuite) TestValidateDepedencies() {
 
 	suite.Require().NotNil(err, "Did not error on invalid tx")
 
-	privs, accNums, accSeqs = []cryptotypes.PrivKey{suite.testAccPriv}, []uint64{7}, []uint64{0}
+	privs, accNums, accSeqs = []cryptotypes.PrivKey{suite.testAccPriv}, []uint64{8}, []uint64{0}
 
 	handlerCtx, cms := aclutils.CacheTxContext(suite.Ctx)
 	validTx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.Ctx.ChainID())

--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/kiichain/kiichain3/x/tokenfactory/types"
 
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
@@ -83,6 +82,5 @@ func (k Keeper) GetCreatorsPrefixStore(ctx sdk.Context) sdk.KVStore {
 // it purely mints and burns them on behalf of the admin of respective denoms,
 // and sends to the relevant address.
 func (k Keeper) CreateModuleAccount(ctx sdk.Context) {
-	moduleAcc := authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter, authtypes.Burner)
-	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
+	k.accountKeeper.GetModuleAccount(ctx, types.ModuleName)
 }

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -31,9 +31,7 @@ type BankKeeper interface {
 }
 
 type AccountKeeper interface {
-	GetModuleAddress(name string) sdk.AccAddress
-	SetModuleAccount(ctx sdk.Context, macc authtypes.ModuleAccountI)
-	GetAccount(sdk.Context, sdk.AccAddress) authtypes.AccountI
+	GetModuleAccount(ctx sdk.Context, moduleName string) authtypes.ModuleAccountI
 }
 
 // DistrKeeper defines the contract needed to be fulfilled for distribution keeper.


### PR DESCRIPTION
# Description

This solves Websoft issue #8:
```
Description:
In tokenfactory/keeper.go, CreateModuleAccount lacks permission checks

Recommendation:
Add module account creation restrictions
Implement privilege checks
```

This removes the current implementation and makes the module use GetModuleAccount for module account creation:
- The GetModuleAccount goes through the validation process
- It can be checked here:
  - https://github.com/KiiChain/kiichain-cosmos/blob/8ab1b94f54b96ffb37edf027895939e953b783cb/x/auth/keeper/keeper.go#L205-L206
  - https://github.com/KiiChain/kiichain-cosmos/blob/8ab1b94f54b96ffb37edf027895939e953b783cb/x/auth/keeper/keeper.go#L181

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

Current tests are enough to validate the current implementation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works