### PR TITLE
Epoch upper bound validation (Websoft #2)

### DIFF
--- a/x/epoch/keeper/grpc_query_epoch_test.go
+++ b/x/epoch/keeper/grpc_query_epoch_test.go
@@ -13,9 +13,9 @@ func TestEpochQuery(t *testing.T) {
 	keeper, ctx := testkeeper.EpochKeeper(t)
 	wctx := sdk.WrapSDKContext(ctx)
 	epoch := types.DefaultEpoch()
-	keeper.SetEpoch(ctx, epoch)
+	keeper.SetEpoch(ctx, *epoch)
 
 	response, err := keeper.Epoch(wctx, &types.QueryEpochRequest{})
 	require.NoError(t, err)
-	require.Equal(t, &types.QueryEpochResponse{Epoch: epoch}, response)
+	require.Equal(t, &types.QueryEpochResponse{Epoch: *epoch}, response)
 }

--- a/x/epoch/types/epoch.go
+++ b/x/epoch/types/epoch.go
@@ -33,7 +33,7 @@ func NewEpoch(
 // DefaultParams returns a default set of parameters
 func DefaultEpoch() *Epoch {
 	// Get now and build a new epoch
-	now := time.Now()
+	now := time.Now().UTC()
 
 	// Return the epoch
 	return NewEpoch(

--- a/x/epoch/types/epoch.go
+++ b/x/epoch/types/epoch.go
@@ -8,6 +8,8 @@ import (
 const (
 	// Default epoch params
 	DefaultEpochDuration = time.Minute
+	DefaultCurrentEpoch  = 0
+	DefaultEpochHeight   = 0
 
 	// MaxEpochDuration is the max epoch duration of one hour
 	MaxEpochDuration = time.Hour
@@ -39,9 +41,9 @@ func DefaultEpoch() *Epoch {
 	return NewEpoch(
 		now,
 		DefaultEpochDuration,
-		0,
+		DefaultCurrentEpoch,
 		now,
-		0,
+		DefaultEpochHeight,
 	)
 }
 

--- a/x/epoch/types/epoch.go
+++ b/x/epoch/types/epoch.go
@@ -1,30 +1,74 @@
 package types
 
-import fmt "fmt"
+import (
+	fmt "fmt"
+	"time"
+)
+
+const (
+	// Default epoch params
+	DefaultEpochDuration = time.Minute
+
+	// MaxEpochDuration is the max epoch duration of one hour
+	MaxEpochDuration = time.Hour
+)
 
 // NewEpoch creates a new Epoch instance
-func NewEpoch() Epoch {
-	return Epoch{}
+func NewEpoch(
+	genesisTime time.Time,
+	epochDuration time.Duration,
+	currentEpoch uint64,
+	currentEpochStartTime time.Time,
+	currentEpochHeight int64,
+) *Epoch {
+	return &Epoch{
+		GenesisTime:           genesisTime,
+		EpochDuration:         epochDuration,
+		CurrentEpoch:          currentEpoch,
+		CurrentEpochStartTime: currentEpochStartTime,
+		CurrentEpochHeight:    currentEpochHeight,
+	}
 }
 
 // DefaultParams returns a default set of parameters
-func DefaultEpoch() Epoch {
-	return NewEpoch()
+func DefaultEpoch() *Epoch {
+	// Get now and build a new epoch
+	now := time.Now()
+
+	// Return the epoch
+	return NewEpoch(
+		now,
+		DefaultEpochDuration,
+		0,
+		now,
+		0,
+	)
 }
 
+// Validate validates the epoch
 func (e *Epoch) Validate() error {
+	// Check if genesis time is zero
 	if e.GetGenesisTime().IsZero() {
 		return fmt.Errorf("epoch genesis time cannot be zero")
 	}
 
-	if e.GetEpochDuration().Seconds() == 0 {
+	// Get the epoch duration to be used on other validators
+	epochDuration := e.GetEpochDuration().Seconds()
+
+	// Check the epoch duration
+	if epochDuration == 0 {
 		return fmt.Errorf("epoch duration cannot be zero")
 	}
+	if epochDuration > MaxEpochDuration.Seconds() {
+		return fmt.Errorf("epoch duration cannot exceed %f seconds (got %f)", MaxEpochDuration.Seconds(), epochDuration)
+	}
 
+	// Check genesis time
 	if e.GetGenesisTime().After(e.GetCurrentEpochStartTime()) {
 		return fmt.Errorf("epoch genesis time cannot be after epoch start time")
 	}
 
+	// Check current epoch height
 	if e.GetCurrentEpochHeight() < 0 {
 		return fmt.Errorf("epoch current epoch height cannot be negative")
 	}

--- a/x/epoch/types/epoch_test.go
+++ b/x/epoch/types/epoch_test.go
@@ -1,0 +1,95 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kiichain/kiichain3/x/epoch/types"
+)
+
+// TestEpochValidation tests the epoch validation process
+func TestEpochValidation(t *testing.T) {
+	// Get now and build a new epoch
+	now := time.Now()
+
+	// Prepare the test cases
+	testCases := []struct {
+		name        string
+		epoch       *types.Epoch
+		errContains string
+	}{
+		{
+			name:  "Good - Default epoch",
+			epoch: types.DefaultEpoch(),
+		},
+		{
+			name: "Bad - Zero genesis time",
+			epoch: types.NewEpoch(
+				time.Time{},
+				types.DefaultEpochDuration,
+				0,
+				now,
+				0,
+			),
+			errContains: "epoch genesis time cannot be zero",
+		},
+		{
+			name: "Bad - Zero duration",
+			epoch: types.NewEpoch(
+				now,
+				0,
+				0,
+				now,
+				0,
+			),
+			errContains: "epoch duration cannot be zero",
+		},
+		{
+			name: "Bad - Giant epoch duration",
+			epoch: types.NewEpoch(
+				now,
+				time.Hour*24, // One day
+				0,
+				now,
+				0,
+			),
+			errContains: "epoch duration cannot exceed 3600.000000 seconds",
+		},
+		{
+			name: "Bad - Genesis time after current epoch start time",
+			epoch: types.NewEpoch(
+				now.Add(time.Second), // One second after current epoch start time
+				types.DefaultEpochDuration,
+				0,
+				now,
+				0,
+			),
+			errContains: "epoch genesis time cannot be after epoch start time",
+		},
+		{
+			name: "Bad - Current epoch heigh negative",
+			epoch: types.NewEpoch(
+				now,
+				types.DefaultEpochDuration,
+				0,
+				now,
+				-1,
+			),
+			errContains: "epoch current epoch height cannot be negative",
+		},
+	}
+
+	// Run all the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.epoch.Validate()
+			if tc.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.errContains)
+			}
+		})
+	}
+}

--- a/x/epoch/types/genesis.go
+++ b/x/epoch/types/genesis.go
@@ -1,25 +1,13 @@
 package types
 
-import "time"
-
-// this line is used by starport scaffolding # genesis/types/import
-
 // DefaultIndex is the default capability global index
 const DefaultIndex uint64 = 1
 
 // DefaultGenesis returns the default Capability genesis state
 func DefaultGenesis() *GenesisState {
-	now := time.Now()
 	return &GenesisState{
-		// this line is used by starport scaffolding # genesis/types/default
 		Params: DefaultParams(),
-		Epoch: &Epoch{
-			GenesisTime:           now,
-			EpochDuration:         time.Minute,
-			CurrentEpoch:          0,
-			CurrentEpochStartTime: now,
-			CurrentEpochHeight:    0,
-		},
+		Epoch:  DefaultEpoch(),
 	}
 }
 


### PR DESCRIPTION
# Description

This solves Websoft issue #2:
```
Description:
HandleUpdateMinterProposal allows complete minter parameter changes with minimal validation.
Recommendation:
Add comprehensive validation suite and rate limiting for minter updates.
```

Add upper bound validation to epoch.
- On the recommendation is says about a governance parameter
- But currently, there's no way to change the epoch after genesis initialization
  - So this PR focus only on the initialization

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

New tests added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works