### PR TITLE
Register module

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -16,6 +16,8 @@ import (
 	"github.com/kiichain/kiichain3/app/antedecorators/depdecorators"
 	evmante "github.com/kiichain/kiichain3/x/evm/ante"
 	evmkeeper "github.com/kiichain/kiichain3/x/evm/keeper"
+	"github.com/kiichain/kiichain3/x/oracle"
+	oraclekeeper "github.com/kiichain/kiichain3/x/oracle/keeper"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
@@ -28,6 +30,7 @@ type HandlerOptions struct {
 	WasmKeeper          *wasm.Keeper
 	AccessControlKeeper *aclkeeper.Keeper
 	EVMKeeper           *evmkeeper.Keeper
+	OracleKeeper        *oraclekeeper.Keeper
 	TXCounterStoreKey   sdk.StoreKey
 	LatestCtxGetter     func() sdk.Context
 
@@ -62,6 +65,9 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 	if options.EVMKeeper == nil {
 		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "evm keeper is required for ante builder")
 	}
+	if options.OracleKeeper == nil {
+		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "oracle keeper is required for ante builder")
+	}
 	if options.LatestCtxGetter == nil {
 		return nil, nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "latest context getter is required for ante builder")
 	}
@@ -75,9 +81,11 @@ func NewAnteHandlerAndDepGenerator(options HandlerOptions) (sdk.AnteHandler, sdk
 
 	anteDecorators := []sdk.AnteFullDecorator{
 		sdk.DefaultWrappedAnteDecorator(ante.NewSetUpContextDecorator(antedecorators.GetGasMeterSetter(options.ParamsKeeper.(paramskeeper.Keeper)))), // outermost AnteDecorator. SetUpContext must be called first
-		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.ParamsKeeper.(paramskeeper.Keeper), options.TxFeeChecker)}, options.EVMKeeper),
+		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.ParamsKeeper.(paramskeeper.Keeper), options.TxFeeChecker)}, options.EVMKeeper, *options.OracleKeeper),
 		sdk.DefaultWrappedAnteDecorator(wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit, antedecorators.GetGasMeterSetter(options.ParamsKeeper.(paramskeeper.Keeper)))), // after setup context to enforce limits early
 		sdk.DefaultWrappedAnteDecorator(ante.NewRejectExtensionOptionsDecorator()),
+		oracle.NewSpammingPreventionDecorator(*options.OracleKeeper), // Register spamming prevention oracle decorator
+		oracle.NewVoteAloneDecorator(),                               // Register oracle vote alone decorator
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateBasicDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewTxTimeoutHeightDecorator()),
 		sdk.DefaultWrappedAnteDecorator(ante.NewValidateMemoDecorator(options.AccountKeeper)),

--- a/app/ante_test.go
+++ b/app/ante_test.go
@@ -100,6 +100,7 @@ func (suite *AnteTestSuite) SetupTest(isCheckTx bool) {
 			WasmKeeper:          &suite.App.WasmKeeper,
 			AccessControlKeeper: &suite.App.AccessControlKeeper,
 			TracingInfo:         tracingInfo,
+			OracleKeeper:        &suite.App.OracleKeeper,
 			EVMKeeper:           &suite.App.EvmKeeper,
 			LatestCtxGetter:     func() sdk.Context { return suite.Ctx },
 		},
@@ -187,7 +188,7 @@ func (suite *AnteTestSuite) TestValidateDepedencies() {
 
 	suite.Require().NotNil(err, "Did not error on invalid tx")
 
-	privs, accNums, accSeqs = []cryptotypes.PrivKey{suite.testAccPriv}, []uint64{8}, []uint64{0}
+	privs, accNums, accSeqs = []cryptotypes.PrivKey{suite.testAccPriv}, []uint64{9}, []uint64{0}
 
 	handlerCtx, cms := aclutils.CacheTxContext(suite.Ctx)
 	validTx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.Ctx.ChainID())

--- a/app/antedecorators/gasless.go
+++ b/app/antedecorators/gasless.go
@@ -4,18 +4,23 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	evmkeeper "github.com/kiichain/kiichain3/x/evm/keeper"
 	evmtypes "github.com/kiichain/kiichain3/x/evm/types"
+	oraclekeeper "github.com/kiichain/kiichain3/x/oracle/keeper"
+	oracletypes "github.com/kiichain/kiichain3/x/oracle/types"
 )
 
+// GaslessDecorator is the struct that has the modules' keeper which are gassless
 type GaslessDecorator struct {
-	wrapped []sdk.AnteFullDecorator
-	// oracleKeeper oraclekeeper.Keeper
-	evmKeeper *evmkeeper.Keeper
+	wrapped      []sdk.AnteFullDecorator
+	oracleKeeper oraclekeeper.Keeper
+	evmKeeper    *evmkeeper.Keeper
 }
 
-func NewGaslessDecorator(wrapped []sdk.AnteFullDecorator, evmKeeper *evmkeeper.Keeper) GaslessDecorator {
-	return GaslessDecorator{wrapped: wrapped, evmKeeper: evmKeeper}
+// NewGaslessDecorator creates a new instance of GaslessDecorator
+func NewGaslessDecorator(wrapped []sdk.AnteFullDecorator, evmKeeper *evmkeeper.Keeper, oracleKeeper oraclekeeper.Keeper) GaslessDecorator {
+	return GaslessDecorator{wrapped: wrapped, evmKeeper: evmKeeper, oracleKeeper: oracleKeeper}
 }
 
 func (gd GaslessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
@@ -23,10 +28,11 @@ func (gd GaslessDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 	// eagerly set infinite gas meter so that queries performed by IsTxGasless will not incur gas cost
 	ctx = ctx.WithGasMeter(storetypes.NewNoConsumptionInfiniteGasMeter())
 
-	isGasless, err := IsTxGasless(tx, ctx, gd.evmKeeper)
+	isGasless, err := IsTxGasless(tx, ctx, gd.evmKeeper, gd.oracleKeeper)
 	if err != nil {
 		return ctx, err
 	}
+
 	if !isGasless {
 		ctx = ctx.WithGasMeter(originalGasMeter)
 	}
@@ -73,7 +79,8 @@ func (gd GaslessDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk
 	return next(append(txDeps, deps...), tx, txIndex)
 }
 
-func IsTxGasless(tx sdk.Tx, ctx sdk.Context, evmKeeper *evmkeeper.Keeper) (bool, error) {
+// IsTxGasless checks the type of the msg and validate if it is registered as gass less tx
+func IsTxGasless(tx sdk.Tx, ctx sdk.Context, evmKeeper *evmkeeper.Keeper, oracleKeeper oraclekeeper.Keeper) (bool, error) {
 	if len(tx.GetMsgs()) == 0 {
 		// empty TX shouldn't be gasless
 		return false, nil
@@ -86,6 +93,11 @@ func IsTxGasless(tx sdk.Tx, ctx sdk.Context, evmKeeper *evmkeeper.Keeper) (bool,
 			}
 			// ddos prevention
 			return len(tx.GetMsgs()) == 1, nil
+		case *oracletypes.MsgAggregateExchangeRateVote:
+			isGassLess, err := oracleVoteIsGassLess(m, ctx, oracleKeeper)
+			if err != nil || !isGassLess {
+				return false, err
+			}
 		default:
 			return false, nil
 		}
@@ -98,4 +110,35 @@ func evmAssociateIsGasless(msg *evmtypes.MsgAssociate, ctx sdk.Context, keeper *
 	kiiAddr := sdk.MustAccAddressFromBech32(msg.Sender)
 	_, associated := keeper.GetEVMAddress(ctx, kiiAddr)
 	return !associated
+}
+
+// oracleVoteIsGassLess checks the msg's info is valid
+func oracleVoteIsGassLess(msg *oracletypes.MsgAggregateExchangeRateVote, ctx sdk.Context, keeper oraclekeeper.Keeper) (bool, error) {
+	// validate feeder address
+	feederAddr, err := sdk.AccAddressFromBech32(msg.Feeder)
+	if err != nil {
+		return false, err
+	}
+
+	// validate validator address
+	valAddr, err := sdk.ValAddressFromBech32(msg.Validator)
+	if err != nil {
+		return false, err
+	}
+
+	// validate the feeder is allowed to send tx
+	err = keeper.ValidateFeeder(ctx, feederAddr, valAddr)
+	if err != nil {
+		return false, err
+	}
+
+	// check the address has votes
+	_, err = keeper.GetAggregateExchangeRateVote(ctx, valAddr)
+	if err != nil {
+		// if there is no error that means there is a vote present, so we don't allow gasless tx
+		err = sdkerrors.Wrap(oracletypes.ErrAggregateVoteExist, valAddr.String())
+		return false, err
+	}
+
+	return true, nil
 }

--- a/app/antedecorators/gasless_test.go
+++ b/app/antedecorators/gasless_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/accesscontrol"
 	"github.com/kiichain/kiichain3/app/antedecorators"
 	evmkeeper "github.com/kiichain/kiichain3/x/evm/keeper"
+	oraclekeeper "github.com/kiichain/kiichain3/x/oracle/keeper"
 )
 
 var output = ""
@@ -84,9 +85,9 @@ func (t FakeTx) FeeGranter() sdk.AccAddress {
 	return nil
 }
 
-func CallGaslessDecoratorWithMsg(ctx sdk.Context, msg sdk.Msg, evmKeeper *evmkeeper.Keeper) error {
+func CallGaslessDecoratorWithMsg(ctx sdk.Context, msg sdk.Msg, evmKeeper *evmkeeper.Keeper, orcleKeeper oraclekeeper.Keeper) error {
 	anteDecorators := []sdk.AnteFullDecorator{
-		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{sdk.DefaultWrappedAnteDecorator(FakeAnteDecoratorGasReqd{})}, evmKeeper),
+		antedecorators.NewGaslessDecorator([]sdk.AnteFullDecorator{sdk.DefaultWrappedAnteDecorator(FakeAnteDecoratorGasReqd{})}, evmKeeper, orcleKeeper),
 	}
 	chainedHandler, depGen := sdk.ChainAnteDecorators(anteDecorators...)
 	fakeTx := FakeTx{

--- a/app/app.go
+++ b/app/app.go
@@ -229,9 +229,7 @@ var (
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 
-	allowedReceivingModAcc = map[string]bool{
-		oracletypes.ModuleName: true, //
-	}
+	allowedReceivingModAcc = map[string]bool{}
 
 	// WasmProposalsEnabled enables all x/wasm proposals when it's value is "true"
 	// and EnableSpecificWasmProposals is empty. Otherwise, all x/wasm proposals
@@ -1003,14 +1001,15 @@ func (app *App) SetStoreUpgradeHandlers() {
 		panic(err)
 	}
 
-	if upgradeInfo.Name == "3.0.0beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{oracletypes.StoreKey},
-		}
+	// TODO: Uncomment when oracle will be release
+	// if upgradeInfo.Name == "3.0.0beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	// 	storeUpgrades := storetypes.StoreUpgrades{
+	// 		Added: []string{oracletypes.StoreKey},
+	// 	}
 
-		// configure store loader that checks if version == upgradeHeight and applies store upgrades
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-	}
+	// 	// configure store loader that checks if version == upgradeHeight and applies store upgrades
+	// 	app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	// }
 
 	if upgradeInfo.Name == "1.1.1beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{

--- a/app/app.go
+++ b/app/app.go
@@ -129,6 +129,9 @@ import (
 	mintclient "github.com/kiichain/kiichain3/x/mint/client/cli"
 	mintkeeper "github.com/kiichain/kiichain3/x/mint/keeper"
 	minttypes "github.com/kiichain/kiichain3/x/mint/types"
+	oraclemodule "github.com/kiichain/kiichain3/x/oracle"
+	oraclekeeper "github.com/kiichain/kiichain3/x/oracle/keeper"
+	oracletypes "github.com/kiichain/kiichain3/x/oracle/types"
 
 	tokenfactorymodule "github.com/kiichain/kiichain3/x/tokenfactory"
 	tokenfactorykeeper "github.com/kiichain/kiichain3/x/tokenfactory/keeper"
@@ -204,6 +207,7 @@ var (
 		wasm.AppModuleBasic{},
 		epochmodule.AppModuleBasic{},
 		tokenfactorymodule.AppModuleBasic{},
+		oraclemodule.AppModuleBasic{},
 		// this line is used by starport scaffolding # stargate/app/moduleBasic
 	)
 
@@ -220,10 +224,14 @@ var (
 		wasm.ModuleName:                {authtypes.Burner},
 		evmtypes.ModuleName:            {authtypes.Minter, authtypes.Burner},
 		tokenfactorytypes.ModuleName:   {authtypes.Minter, authtypes.Burner},
+		oracletypes.ModuleName:         nil,
+
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 
-	allowedReceivingModAcc = map[string]bool{}
+	allowedReceivingModAcc = map[string]bool{
+		oracletypes.ModuleName: true, //
+	}
 
 	// WasmProposalsEnabled enables all x/wasm proposals when it's value is "true"
 	// and EnableSpecificWasmProposals is empty. Otherwise, all x/wasm proposals
@@ -323,6 +331,7 @@ type App struct {
 	FeeGrantKeeper      feegrantkeeper.Keeper
 	WasmKeeper          wasm.Keeper
 	EvmKeeper           evmkeeper.Keeper
+	OracleKeeper        oraclekeeper.Keeper
 
 	// make scoped keepers public for test purposes
 	ScopedIBCKeeper      capabilitykeeper.ScopedKeeper
@@ -404,10 +413,11 @@ func New(
 		evmtypes.StoreKey, wasm.StoreKey,
 		epochmoduletypes.StoreKey,
 		tokenfactorytypes.StoreKey,
+		oracletypes.StoreKey,
 		// this line is used by starport scaffolding # stargate/app/storeKey
 	)
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey, evmtypes.TransientStoreKey)
-	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, banktypes.DeferredCacheStoreKey)
+	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, banktypes.DeferredCacheStoreKey, oracletypes.MemStoreKey)
 
 	app := &App{
 		BaseApp:           bApp,
@@ -535,6 +545,17 @@ func New(
 		tokenFactoryConfig,
 	)
 
+	app.OracleKeeper = oraclekeeper.NewKeeper(
+		appCodec,
+		keys[oracletypes.StoreKey],
+		memKeys[oracletypes.MemStoreKey],
+		app.GetSubspace(oracletypes.ModuleName),
+		app.AccountKeeper,
+		app.BankKeeper,
+		app.StakingKeeper,
+		distrtypes.ModuleName,
+	)
+
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
 	supportedFeatures := "iterator,staking,stargate,sei"
@@ -659,6 +680,7 @@ func New(
 		AddRoute(tokenfactorytypes.RouterKey, tokenfactorymodule.NewProposalHandler(app.TokenFactoryKeeper)).
 		AddRoute(acltypes.ModuleName, aclmodule.NewProposalHandler(app.AccessControlKeeper)).
 		AddRoute(evmtypes.RouterKey, evm.NewProposalHandler(app.EvmKeeper))
+		// FIXME: Add proposal handler for oracle Module
 	if len(enabledProposals) != 0 {
 		govRouter.AddRoute(wasm.RouterKey, wasm.NewWasmProposalHandler(app.WasmKeeper, enabledProposals))
 	}
@@ -693,6 +715,7 @@ func New(
 			app.IBCKeeper.ConnectionKeeper,
 			app.IBCKeeper.ChannelKeeper,
 			app.AccountKeeper,
+			// app.OracleKeeper, // FIXME: Uncomment when precompiles are set
 		); err != nil {
 			panic(err)
 		}
@@ -734,6 +757,7 @@ func New(
 		epochModule,
 		tokenfactorymodule.NewAppModule(app.TokenFactoryKeeper, app.AccountKeeper, app.BankKeeper),
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
+		oraclemodule.NewAppModule(appCodec, app.OracleKeeper, app.AccountKeeper, app.BankKeeper),
 		// this line is used by starport scaffolding # stargate/app/appModule
 	)
 
@@ -761,10 +785,15 @@ func New(
 		vestingtypes.ModuleName,
 		ibchost.ModuleName,
 		ibctransfertypes.ModuleName,
+		oracletypes.ModuleName, // register oracle begin blocker
 		evmtypes.ModuleName,
 		wasm.ModuleName,
 		tokenfactorytypes.ModuleName,
 		acltypes.ModuleName,
+	)
+
+	app.mm.SetOrderMidBlockers(
+		oracletypes.ModuleName, // register oracle mid blocker
 	)
 
 	app.mm.SetOrderEndBlockers(
@@ -786,6 +815,7 @@ func New(
 		vestingtypes.ModuleName,
 		ibchost.ModuleName,
 		ibctransfertypes.ModuleName,
+		oracletypes.ModuleName, // register oracle end blocker
 		epochmoduletypes.ModuleName,
 		evmtypes.ModuleName,
 		wasm.ModuleName,
@@ -817,6 +847,7 @@ func New(
 		ibctransfertypes.ModuleName,
 		authz.ModuleName,
 		feegrant.ModuleName,
+		oracletypes.ModuleName, // register oracle init genesis
 		tokenfactorytypes.ModuleName,
 		epochmoduletypes.ModuleName,
 		wasm.ModuleName,
@@ -885,6 +916,7 @@ func New(
 			TXCounterStoreKey:   keys[wasm.StoreKey],
 			WasmConfig:          &wasmConfig,
 			WasmKeeper:          &app.WasmKeeper,
+			OracleKeeper:        &app.OracleKeeper,
 			EVMKeeper:           &app.EvmKeeper,
 			TracingInfo:         app.GetBaseApp().TracingInfo,
 			AccessControlKeeper: &app.AccessControlKeeper,
@@ -969,6 +1001,15 @@ func (app *App) SetStoreUpgradeHandlers() {
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(err)
+	}
+
+	if upgradeInfo.Name == "3.0.0beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{oracletypes.StoreKey},
+		}
+
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 
 	if upgradeInfo.Name == "1.1.1beta" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
@@ -1834,7 +1875,7 @@ func (app *App) checkTotalBlockGasWanted(ctx sdk.Context, txs [][]byte) bool {
 			continue
 		}
 		// check gasless first (this has to happen before other checks to avoid panics)
-		isGasless, err := antedecorators.IsTxGasless(decodedTx, ctx, &app.EvmKeeper)
+		isGasless, err := antedecorators.IsTxGasless(decodedTx, ctx, &app.EvmKeeper, app.OracleKeeper)
 		if err != nil {
 			ctx.Logger().Error("error checking if tx is gasless", "error", err)
 			continue
@@ -1912,6 +1953,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(evmtypes.ModuleName)
 	paramsKeeper.Subspace(epochmoduletypes.ModuleName)
 	paramsKeeper.Subspace(tokenfactorytypes.ModuleName)
+	paramsKeeper.Subspace(oracletypes.ModuleName) // register oracle params
 	// this line is used by starport scaffolding # stargate/app/paramSubspace
 
 	return paramsKeeper

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-/* setUp conditions:
+/* SetUp conditions:
 voting target:
 - uatom
 - ueth
@@ -31,7 +31,7 @@ ballot threshold: 20 power units
 func TestMidBlocker(t *testing.T) {
 	t.Run("Success case - Exchange rate created on KVStore", func(t *testing.T) {
 		// Reset blockchain state
-		input, handler := setUp(t)
+		input, handler := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 
@@ -58,7 +58,7 @@ func TestMidBlocker(t *testing.T) {
 
 	t.Run("Success case - snapshot created", func(t *testing.T) {
 		// Reset blockchain state
-		input, handler := setUp(t)
+		input, handler := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 
@@ -86,7 +86,7 @@ func TestMidBlocker(t *testing.T) {
 
 	t.Run("Error case - Ballot power less than threshold", func(t *testing.T) {
 		// Reset blockchain state
-		input, handler := setUp(t)
+		input, handler := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 
@@ -109,7 +109,7 @@ func TestMidBlocker(t *testing.T) {
 
 	t.Run("Validator does not vote - AbstainCount should increase", func(t *testing.T) {
 		// Reset blockchain state
-		input, handler := setUp(t)
+		input, handler := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 
@@ -134,7 +134,7 @@ func TestMidBlocker(t *testing.T) {
 
 	t.Run("Validator votes out of acceptable range - Should count as Miss", func(t *testing.T) {
 		// Reset blockchain state
-		input, handler := setUp(t)
+		input, handler := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 
@@ -165,7 +165,7 @@ func TestMidBlocker(t *testing.T) {
 
 	t.Run("Verify upgrading the vote targets", func(t *testing.T) {
 		// Reset blockchain state
-		input, _ := setUp(t)
+		input, _ := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 
@@ -209,7 +209,7 @@ func TestMidBlocker(t *testing.T) {
 
 func TestOracleDrop(t *testing.T) {
 	// Reset blockchain state
-	input, handler := setUp(t)
+	input, handler := SetUp(t)
 	ctx := input.Ctx
 	oracleKeeper := input.OracleKeeper
 	ctx = input.Ctx.WithBlockHeight(1)
@@ -235,8 +235,8 @@ func TestOracleDrop(t *testing.T) {
 
 func TestEndblocker(t *testing.T) {
 	t.Run("Validator Jailed - success voting below min valid per window", func(t *testing.T) {
-		// Setup blockchain state
-		input, _ := setUp(t)
+		// SetUp blockchain state
+		input, _ := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 		stakingKeeper := input.StakingKeeper
@@ -270,8 +270,8 @@ func TestEndblocker(t *testing.T) {
 	})
 
 	t.Run("Validator not jailed", func(t *testing.T) {
-		// Setup blockchain state
-		input, _ := setUp(t)
+		// SetUp blockchain state
+		input, _ := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 		stakingKeeper := input.StakingKeeper
@@ -305,8 +305,8 @@ func TestEndblocker(t *testing.T) {
 	})
 
 	t.Run("Success remove excess feeds", func(t *testing.T) {
-		// Setup blockchain state
-		input, _ := setUp(t)
+		// SetUp blockchain state
+		input, _ := SetUp(t)
 		ctx := input.Ctx
 		oracleKeeper := input.OracleKeeper
 

--- a/x/oracle/ante.go
+++ b/x/oracle/ante.go
@@ -1,0 +1,163 @@
+package oracle
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/kiichain/kiichain3/x/oracle/keeper"
+	"github.com/kiichain/kiichain3/x/oracle/types"
+)
+
+// SpammingPreventionDecorator will check if
+type SpammingPreventionDecorator struct {
+	oracleKepper keeper.Keeper
+}
+
+// NewSpammingPreventionDecorator creates a new instance of spamming prevention decorator
+func NewSpammingPreventionDecorator(keeper keeper.Keeper) SpammingPreventionDecorator {
+	return SpammingPreventionDecorator{
+		oracleKepper: keeper,
+	}
+}
+
+// AnteHandle is the handler that checks if the transaction's validator has voted previously
+func (spd SpammingPreventionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if ctx.IsReCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
+	if !simulate && ctx.IsCheckTx() {
+		err := spd.CheckOracleSpamming(ctx, tx.GetMsgs())
+		if err != nil {
+			return ctx, err
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// CheckOracleSpamming checks whether the msgs are spamming purpose or not
+func (spd SpammingPreventionDecorator) CheckOracleSpamming(ctx sdk.Context, msgs []sdk.Msg) error {
+	currentHeight := ctx.BlockHeight()
+
+	for _, msg := range msgs {
+		switch msg := msg.(type) {
+		case *types.MsgAggregateExchangeRateVote:
+			// validate a valid feeder address
+			feederAddr, err := sdk.AccAddressFromBech32(msg.Feeder)
+			if err != nil {
+				return err
+			}
+
+			// validate a valid validator address
+			valAddr, err := sdk.ValAddressFromBech32(msg.Validator)
+			if err != nil {
+				return err
+			}
+
+			// validate the feeder delegation is valid
+			err = spd.oracleKepper.ValidateFeeder(ctx, feederAddr, valAddr)
+			if err != nil {
+				return err
+			}
+
+			// check if the validator has voted on that block height
+			spamPreventionHeight := spd.oracleKepper.GetSpamPreventionCounter(ctx, valAddr)
+			if spamPreventionHeight == currentHeight {
+				return sdkerrors.Wrap(sdkerrors.ErrAlreadyExists, fmt.Sprintf("the validator has already submitted a vote at the current height=%d", currentHeight))
+			}
+
+			// set the anti spam block height
+			spd.oracleKepper.SetSpamPreventionCounter(ctx, valAddr)
+			continue
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// AnteDeps implements the AnteFullDecorator interface, required to register SpammingPreventionDecorator as decorator
+func (spd SpammingPreventionDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) ([]sdkacltypes.AccessOperation, error) {
+	deps := []sdkacltypes.AccessOperation{} // Here I will store the dependencies
+
+	// Iterate over all messages inside the transaction
+	for _, msg := range tx.GetMsgs() {
+		switch msg := msg.(type) {
+
+		// Process the aggregate exchange rate messages
+		case *types.MsgAggregateExchangeRateVote:
+			valAddrs, _ := sdk.ValAddressFromBech32(msg.Feeder)
+			deps = append(deps, []sdkacltypes.AccessOperation{
+				// validate feeder
+				{
+					ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_FEEDERS,
+					AccessType:         sdkacltypes.AccessType_READ,
+					IdentifierTemplate: hex.EncodeToString(types.GetFeederDelegationKey(valAddrs)),
+				},
+
+				// Validate the validator exists
+				{
+					ResourceType:       sdkacltypes.ResourceType_KV_STAKING_VALIDATOR,
+					AccessType:         sdkacltypes.AccessType_READ,
+					IdentifierTemplate: hex.EncodeToString(stakingtypes.GetValidatorKey(valAddrs)),
+				},
+
+				// Check exchange rate exists
+				{
+					ResourceType:       sdkacltypes.ResourceType_KV_ORACLE_AGGREGATE_VOTES,
+					AccessType:         sdkacltypes.AccessType_READ,
+					IdentifierTemplate: hex.EncodeToString(types.GetAggregateExchangeRateVoteKey(valAddrs)),
+				},
+			}...)
+		default:
+			continue
+		}
+	}
+
+	// add the new dependencies (deps) with the previous ones (txDeps) and are passed to the next decorator
+	return next(append(txDeps, deps...), tx, txIndex)
+}
+
+// VoteAloneDecorator implements the AnteFullDecorator needed to be registrated as a decorator
+type VoteAloneDecorator struct{}
+
+// NewVoteAloneDecorator returns a new instance of VoteAloneDecorator
+func NewVoteAloneDecorator() VoteAloneDecorator {
+	return VoteAloneDecorator{}
+}
+
+// AnteHandle implements the AnteDecorator interfaces on the
+// AnteHandler checks
+func (VoteAloneDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	oracleVote := false
+	otherMsg := false
+
+	// Iterate over all messages on the transaction
+	for _, msg := range tx.GetMsgs() {
+		switch msg.(type) {
+		case *types.MsgAggregateExchangeRateVote:
+			oracleVote = true
+		default:
+			otherMsg = true
+		}
+	}
+
+	if oracleVote && otherMsg {
+		return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "oracle votes cannot be in the same tx as other messages")
+	}
+
+	// Continue on the next decorator
+	return next(ctx, tx, simulate)
+}
+
+// AnteDeps implements the AnteDepDecorator interface
+// AnteDeps collects the dependencies the vote alone decorator needs
+func (VoteAloneDecorator) AnteDeps(txDeps []sdkacltypes.AccessOperation, tx sdk.Tx, txIndex int, next sdk.AnteDepGenerator) (newTxDeps []sdkacltypes.AccessOperation, err error) {
+	// requires no dependencies
+	return next(txDeps, tx, txIndex)
+}

--- a/x/oracle/ante_test.go
+++ b/x/oracle/ante_test.go
@@ -1,0 +1,158 @@
+package oracle_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkacltypes "github.com/cosmos/cosmos-sdk/types/accesscontrol"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	aclutils "github.com/kiichain/kiichain3/aclmapping/utils"
+	"github.com/kiichain/kiichain3/app"
+	"github.com/kiichain/kiichain3/x/oracle"
+	"github.com/kiichain/kiichain3/x/oracle/keeper"
+	"github.com/kiichain/kiichain3/x/oracle/types"
+	"github.com/kiichain/kiichain3/x/oracle/utils"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestVoteAloneHandle(t *testing.T) {
+	type testCase struct {
+		name          string
+		expectedError bool
+		tx            sdk.Tx
+	}
+
+	// these are the test messages
+	testOracleMsg := types.MsgAggregateExchangeRateVote{}
+	testNoOracleMsg := banktypes.MsgSend{}
+	testNoOracleMsg2 := banktypes.MsgSend{}
+
+	// register oracle vote alone decorator
+	decorator := oracle.NewVoteAloneDecorator()
+	anteHandler, depGen := sdk.ChainAnteDecorators(decorator)
+
+	testCases := []testCase{
+		// ante handle wil continue this
+		{name: "only oracle votes",
+			expectedError: false,
+			tx:            app.NewTestTx([]sdk.Msg{&testOracleMsg}),
+		},
+
+		// ante handle will ignore this message
+		{name: "only non-oracle votes",
+			expectedError: false,
+			tx:            app.NewTestTx([]sdk.Msg{&testNoOracleMsg, &testNoOracleMsg2}),
+		},
+
+		// ante handle will return an error because the oracle message can not be with other messages
+		{name: "mixed messages",
+			expectedError: true,
+			tx:            app.NewTestTx([]sdk.Msg{&testOracleMsg, &testNoOracleMsg, &testNoOracleMsg2}),
+		},
+	}
+
+	// Iterate cases
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// Create context
+			ctx := sdk.NewContext(nil, tmproto.Header{}, false, nil)
+
+			// execute ante handler
+			_, err := anteHandler(ctx, test.tx, false)
+			if test.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Generate dependencies
+			_, err = depGen([]sdkacltypes.AccessOperation{}, test.tx, 1)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSpammingPreventionHandle(t *testing.T) {
+	// Prepare env
+	input, _ := oracle.SetUp(t)
+	ctx := input.Ctx
+	oracleKeeper := input.OracleKeeper
+
+	// Create test exchange rate
+	randomAExchangeRate := sdk.NewDec(1700)
+	exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+
+	voteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[0], keeper.ValAddrs[0])
+	invalidVoteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[5], keeper.ValAddrs[2]) // addr 3 has not been delegated by val 2
+
+	// Register anti spamming decorator
+	spammingDecorator := oracle.NewSpammingPreventionDecorator(oracleKeeper)
+	anteHandler, _ := sdk.ChainAnteDecorators(spammingDecorator)
+
+	// should skip the ante handler because the context is set as Recheck
+	recheckCtx := ctx.WithIsReCheckTx(true)
+	_, err := anteHandler(recheckCtx, app.NewTestTx([]sdk.Msg{voteMsg}), false)
+	require.NoError(t, err)
+
+	// should return error because the feeder is not valid
+	checkCtx := ctx.WithIsCheckTx(true)
+	require.True(t, checkCtx.IsCheckTx()) // validate ctx has IsCheckTx active
+	_, err = anteHandler(checkCtx, app.NewTestTx([]sdk.Msg{invalidVoteMsg}), false)
+	require.Error(t, err)
+
+	// should return error because of feeder malform
+	malformFeeder := voteMsg
+	malformFeeder.Feeder = "kiifeeder"
+	_, err = anteHandler(checkCtx, app.NewTestTx([]sdk.Msg{malformFeeder}), false)
+	require.Error(t, err)
+
+	// should return error because of validator malform
+	malformVal := voteMsg
+	malformVal.Feeder = "kiivalidator"
+	_, err = anteHandler(checkCtx, app.NewTestTx([]sdk.Msg{malformVal}), false)
+	require.Error(t, err)
+
+	// should fail, no exchange rate on message
+	exRate, _ := types.NewAggregateExchangeRateVote(types.ExchangeRateTuples{}, keeper.ValAddrs[0])
+	oracleKeeper.SetAggregateExchangeRateVote(ctx, keeper.ValAddrs[0], exRate)
+	_, err = anteHandler(checkCtx, app.NewTestTx([]sdk.Msg{voteMsg}), false)
+	require.Error(t, err)
+}
+
+func TestSpammingPreventionAnteDeps(t *testing.T) {
+	// Prepare env
+	input, _ := oracle.SetUp(t)
+	ctx := input.Ctx
+	oracleKeeper := input.OracleKeeper
+
+	// Create test exchange rate
+	randomAExchangeRate := sdk.NewDec(1700)
+	exchangeRate := randomAExchangeRate.String() + utils.MicroAtomDenom
+	voteMsg := types.NewMsgAggregateExchangeRateVote(exchangeRate, keeper.Addrs[0], keeper.ValAddrs[0]) // create aggregate exchange rate msg
+
+	// Register spamming decorator
+	spammingDecorator := oracle.NewSpammingPreventionDecorator(oracleKeeper)
+	anteHandler, depGen := sdk.ChainAnteDecorators(spammingDecorator)
+
+	// Prepare context
+	ctx = ctx.WithIsCheckTx(true)
+	msgValidator := sdkacltypes.NewMsgValidator(aclutils.StoreKeyToResourceTypePrefixMap)
+	ctx = ctx.WithMsgValidator(msgValidator)
+	ms := ctx.MultiStore()
+	msCache := ms.CacheMultiStore()
+	ctx = ctx.WithMultiStore(msCache)
+	tx := app.NewTestTx([]sdk.Msg{voteMsg})
+
+	_, err := anteHandler(ctx, tx, false)
+	require.NoError(t, err)
+
+	newDeps, err := depGen([]sdkacltypes.AccessOperation{}, tx, 1)
+	require.NoError(t, err)
+
+	storeAccessOpEvents := msCache.GetEvents()
+
+	// require
+	missingAccessOps := ctx.MsgValidator().ValidateAccessOperations(newDeps, storeAccessOpEvents)
+	require.Equal(t, 0, len(missingAccessOps))
+}

--- a/x/oracle/client/cli/tx.go
+++ b/x/oracle/client/cli/tx.go
@@ -26,7 +26,7 @@ func GetTxCmd() *cobra.Command {
 	// Add Tx commands
 	oracleTxCmd.AddCommand(
 		CmdDelegateFeederPermission(),
-		CmdDelegateFeederPermission(),
+		CmdAggregateExchangeRateVote(),
 	)
 
 	return oracleTxCmd

--- a/x/oracle/genesis.go
+++ b/x/oracle/genesis.go
@@ -10,6 +10,9 @@ import (
 
 // InitGenesis initialize the module with the default parameters
 func InitGenesis(ctx sdk.Context, keeper keeper.Keeper, data *types.GenesisState) {
+	// Create module account
+	keeper.CreateModuleAccount(ctx)
+
 	// Start the genesis with the data input
 	keeper.SetParams(ctx, data.Params)
 

--- a/x/oracle/keeper/genesis.go
+++ b/x/oracle/keeper/genesis.go
@@ -1,0 +1,14 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/kiichain/kiichain3/x/evm/types"
+)
+
+// CreateModuleAccount creates a module account with minting and burning capabilities
+// This account isn't intended to store any coins, it purely mints and burns them
+func (k Keeper) CreateModuleAccount(ctx sdk.Context) {
+	moduleAcc := authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter, authtypes.Burner)
+	k.accountKeeper.SetModuleAccount(ctx, moduleAcc)
+}

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -34,7 +34,7 @@ func NewKeeper(cdc codec.BinaryCodec, storeKey sdk.StoreKey, memKey sdk.StoreKey
 	distrName string) Keeper {
 	// Ensure oracle module account is set
 	addr := accountKeeper.GetModuleAddress(types.ModuleName)
-	if addr != nil {
+	if addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
 	}
 

--- a/x/oracle/keeper/test_utils.go
+++ b/x/oracle/keeper/test_utils.go
@@ -145,6 +145,7 @@ func CreateTestInput(t *testing.T) TestInput {
 		stakingTypes.BondedPoolName:    true,
 		distTypes.ModuleName:           true,
 		faucetAccountName:              true,
+		types.ModuleName:               true,
 	}
 
 	// Define account's permissions
@@ -154,6 +155,7 @@ func CreateTestInput(t *testing.T) TestInput {
 		stakingTypes.BondedPoolName:    {authTypes.Burner, authTypes.Staking},
 		distTypes.ModuleName:           {authTypes.Burner, authTypes.Staking},
 		faucetAccountName:              {authTypes.Minter},
+		types.ModuleName:               {authTypes.Minter, authTypes.Burner},
 	}
 
 	// Init account, bank and staking keepers
@@ -214,6 +216,10 @@ func CreateTestInput(t *testing.T) TestInput {
 		err := bankKeeper.SendCoinsFromModuleToAccount(ctx, faucetAccountName, addr, InitialCoins)
 		require.NoError(t, err) // Validate the operation
 	}
+
+	// check the module account set
+	addr := accountKeeper.GetModuleAddress(types.ModuleName)
+	require.NotNil(t, addr, "Oracle account was not set")
 
 	// Set Oracle module
 	oracleKeeper := NewKeeper(appCodec, keyOracle, memKeys[types.MemStoreKey], paramsKeeper.Subspace(types.ModuleName),

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -1,12 +1,14 @@
 package oracle
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -15,49 +17,42 @@ import (
 	"github.com/kiichain/kiichain3/x/oracle/keeper"
 	"github.com/kiichain/kiichain3/x/oracle/types"
 	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 var (
-	// _ module.AppModule      = AppModule{} // Indirect implement the AppModule interface
-	_ module.AppModuleBasic = AppModule{} // Indirect implement the AppModuleBasic interface
+	_ module.AppModule      = AppModule{}      // Indirect implement the AppModule interface
+	_ module.AppModuleBasic = AppModuleBasic{} // Indirect implement the AppModuleBasic interface
 )
 
-// AppModule implements the Cosmos SDK AppModule interface
-type AppModule struct {
-	cdc    codec.Codec
-	Kepper keeper.Keeper
-}
-
-// NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper) AppModule {
-	return AppModule{
-		cdc:    cdc,
-		Kepper: keeper,
-	}
-}
-
-// ********************* IMPLEMENT AppModule INTERFACE ************************
-
-// ****************************************************************************
-
 // ********************* IMPLEMENT AppModuleBasic INTERFACE ******************
-func (AppModule) Name() string {
+
+// AppModuleBasic defines the basic application module
+type AppModuleBasic struct {
+	cdc codec.Codec
+}
+
+// Name returns the module name
+func (AppModuleBasic) Name() string {
 	return types.ModuleName
 }
 
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	types.RegisterCodec(cdc)
 }
 
-func (AppModule) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+// RegisterInterfaces registers the request messages on the tx rpc
+func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
 }
 
-func (AppModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+// DefaultGenesis returns the default genesis state
+func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	return cdc.MustMarshalJSON(types.DefaultGenesisState())
 }
 
-func (AppModule) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
+// ValidateGenesis performs a genesis state validation
+func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
 	var data types.GenesisState
 	err := cdc.UnmarshalJSON(bz, &data)
 	if err != nil {
@@ -66,7 +61,8 @@ func (AppModule) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingCo
 	return types.ValidateGenesis(&data)
 }
 
-func (appModule AppModule) ValidateGenesisStream(cdc codec.JSONCodec, config client.TxEncodingConfig, genesisCh <-chan json.RawMessage) error {
+// ValidateGenesisStream performs a genesis validation in a streaming fashion
+func (appModule AppModuleBasic) ValidateGenesisStream(cdc codec.JSONCodec, config client.TxEncodingConfig, genesisCh <-chan json.RawMessage) error {
 	for genesis := range genesisCh {
 		err := appModule.ValidateGenesis(cdc, config, genesis)
 		if err != nil {
@@ -76,22 +72,113 @@ func (appModule AppModule) ValidateGenesisStream(cdc codec.JSONCodec, config cli
 	return nil
 }
 
-func (AppModule) RegisterRESTRoutes(clientCtx client.Context, router *mux.Router) {
+// RegisterRESTRoutes registers the REST routes
+func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, router *mux.Router) {
 	rest.RegisterRoutes(clientCtx, router)
 }
 
-func (AppModule) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	// TODO: Register gRPC query routes
+// RegisterGRPCGatewayRoutes registers the gRPC query routes
+func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+	err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	if err != nil {
+		panic(err)
+	}
 }
 
 // GetTxCmd returns the cli tx commands for the module
-func (AppModule) GetTxCmd() *cobra.Command {
+func (AppModuleBasic) GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
 }
 
 // GetQueryCmd returns the cli query commands for the module
-func (AppModule) GetQueryCmd() *cobra.Command {
+func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 	return cli.GetQueryCmd()
+}
+
+// ****************************************************************************
+
+// AppModule implements an application module (AppModule interface)
+type AppModule struct {
+	AppModuleBasic
+	Kepper        keeper.Keeper
+	accountKeeper types.AccountKeeper
+	bankKeeper    types.BankKeeper
+}
+
+// NewAppModule creates a new AppModule object
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, accountKeeper types.AccountKeeper, bankKeeper types.BankKeeper) AppModule {
+	return AppModule{
+		AppModuleBasic: AppModuleBasic{
+			cdc: cdc,
+		},
+		accountKeeper: accountKeeper,
+		bankKeeper:    bankKeeper,
+		Kepper:        keeper,
+	}
+}
+
+// ********************* IMPLEMENT AppModule INTERFACE ************************
+// ConsensusVersion returns the version the module's version
+func (AppModule) ConsensusVersion() uint64 { return 6 }
+
+// RegisterServices registers the module services
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServer(am.Kepper))
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(am.Kepper))
+}
+
+// RegisterInvariants
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+
+// InitGenesis trigger the genesis initialization
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
+	genesis := &types.GenesisState{}
+	cdc.MustUnmarshalJSON(data, genesis)
+	InitGenesis(ctx, am.Kepper, genesis)
+	return nil
+}
+
+// ExportGenesis returns the current genesis state as json
+func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+	genesis := ExportGenesis(ctx, am.Kepper)
+	return cdc.MustMarshalJSON(&genesis)
+}
+
+// ExportGenesisStream returns genesis state as json bytes in a streaming fashion
+func (am AppModule) ExportGenesisStream(ctx sdk.Context, cdc codec.JSONCodec) <-chan json.RawMessage {
+	ch := make(chan json.RawMessage)
+	go func() {
+		ch <- am.ExportGenesis(ctx, cdc)
+		close(ch)
+	}()
+	return ch
+}
+
+// LegacyQuerierHandler returns the module sdk.Querier (deprecated)
+func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
+	return nil
+}
+
+// Route returns the module's routing key (deprecated)
+func (am AppModule) Route() sdk.Route {
+	return sdk.NewRoute(types.RouterKey, NewHandler(am.Kepper))
+}
+
+// QuerierRoute returns the module's querier router name
+func (am AppModule) QuerierRoute() string { return types.QuerierRoute }
+
+// BeginBlock returns the module's begin blocker
+func (am AppModule) BeginBlock(_ sdk.Context, _ int64) {}
+
+// MidBlock returns the module's mid blocker
+func (am AppModule) MidBlock(ctx sdk.Context, _ int64) {
+	MidBlocker(ctx, am.Kepper)
+}
+
+// EndBlock returns the module's end blocker
+func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) (res []abci.ValidatorUpdate) {
+	Endblocker(ctx, am.Kepper)
+	return []abci.ValidatorUpdate{}
 }
 
 // ****************************************************************************

--- a/x/oracle/test_helpers.go
+++ b/x/oracle/test_helpers.go
@@ -15,7 +15,7 @@ var (
 	randomBExchangeRate = sdk.NewDecWithPrec(4882, 2)
 )
 
-func setUp(t *testing.T) (keeper.TestInput, sdk.Handler) {
+func SetUp(t *testing.T) (keeper.TestInput, sdk.Handler) {
 	input := keeper.CreateTestInput(t)
 	oracleKeeper := input.OracleKeeper
 	stakingKeeper := input.StakingKeeper

--- a/x/oracle/types/codec.go
+++ b/x/oracle/types/codec.go
@@ -3,14 +3,21 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
-// RegisterCodec register the messages for transactions
+// RegisterCodec registers the messages for transactions
 func RegisterCodec(cdc *codec.LegacyAmino) {
-
+	cdc.RegisterConcrete(&MsgAggregateExchangeRateVote{}, "oracle/MsgAggregateExchangeRateVote", nil)
+	cdc.RegisterConcrete(&MsgDelegateFeedConsent{}, "oracle/MsgDelegateFeedConsent", nil)
 }
 
-// RegisterInterfaces
+// RegisterInterfaces registers the request messages on the tx rpc
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
-
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgAggregateExchangeRateVote{},
+		&MsgDelegateFeedConsent{},
+	)
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/oracle/types/expected_keepers.go
+++ b/x/oracle/types/expected_keepers.go
@@ -23,6 +23,7 @@ type StakingKeeper interface {
 type AccountKeeper interface {
 	GetModuleAddress(name string) sdk.AccAddress                                  //Ensures the oracle module has an account
 	GetModuleAccount(ctx sdk.Context, moduleName string) authtypes.ModuleAccountI // Retrieves detailed account information
+	SetModuleAccount(ctx sdk.Context, macc authtypes.ModuleAccountI)              // Creates a module account
 }
 
 // BankKeeper is expected keeper for bank module, because I need to handle

--- a/x/oracle/types/msgs.go
+++ b/x/oracle/types/msgs.go
@@ -81,12 +81,12 @@ func NewMsgDelegateFeedConsent(operatorAddress sdk.ValAddress, feederAddress sdk
 // GetSigners implements sdk.Msg interface
 // Returns the signer of the transaction which is the feeder
 func (msg MsgDelegateFeedConsent) GetSigners() []sdk.AccAddress {
-	feeder, err := sdk.AccAddressFromBech32(msg.Operator)
+	operator, err := sdk.ValAddressFromBech32(msg.Operator)
 	if err != nil {
 		panic(err)
 	}
 
-	return []sdk.AccAddress{feeder}
+	return []sdk.AccAddress{sdk.AccAddress(operator)}
 }
 
 // ValidateBasic implements sdk.Msg interface


### PR DESCRIPTION
# Description

These changes make the following:
- Create the oracle module ante (for spam prevention and gassless)
- Create the module's gassless configuration (evidence attached)
- Register the ante and gassless on the App.go
- Register the Oracle module on the App.go
- Fix an error on the CLI tx (a command was duplicated)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates documentation on the project)
- [ ] chore (Updates on dependencies, gitignore, etc)
- [ ] test (For updates on tests)

# How Has This Been Tested?

These changes were tested with their unit test and locally. Here is an evidence of the ddos handle tx, my local validator has already voted on the voting window:
![image](https://github.com/user-attachments/assets/6666408a-eb73-4fa9-a109-6c5e6e1db7aa)


